### PR TITLE
PYTHON_EXECUTABLE -> Python_EXECUTABLE

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -51,7 +51,7 @@ class NLOptBuild(build_ext):
             "cmake",
             "-LAH",
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={_ed}",
-            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DPython_EXECUTABLE={sys.executable}",
             "-DNLOPT_GUILE=OFF",
             "-DNLOPT_MATLAB=OFF",
             "-DNLOPT_OCTAVE=OFF",


### PR DESCRIPTION
The environment variable name in cmake is spelled a bit strangely (Python_EXECUTABLE) but the extensions.py script spelled it PYTHON_EXECUTABLE. This was causing nlopt not to build on my macOS box.

This commit fixes that environment variable name and now it builds on my arm Mac running Ventura.

Please do let me know if you want any specific testing to make sure I haven't broken anything else!