### PR TITLE
 build.yml -> change macos-latest to macos-13 to re-enable x86_64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-14 ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest, macos-latest, macos-14 ]
+        os: [ windows-latest, ubuntu-latest, macos-13, macos-14 ]
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:


### PR DESCRIPTION
referencing issue https://github.com/DanielBok/nlopt-python/issues/39 I can confirm that no MacOS-x86_64 builds are available for nlopt==2.8.0 https://pypi.org/project/nlopt/#files

As I mentioned in https://github.com/DanielBok/nlopt-python/pull/34 currently the "safest" way to get both builds is to manually specify macos-13 and macos-14, which are x86_64 and arm64 (aka aarch64 aka m1/2/3/etc) runners respectively.

This PR is an attempt to fix this problem.