### PR TITLE
ci: build aarch64 manylinux wheels on ubuntu-24.04-arm runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,9 @@ jobs:
           # only build CPython-3.10+ and skip 32-bit builds
           CIBW_BUILD: ${{ needs.setup.outputs.cibw-build }}
           CIBW_SKIP: "*-manylinux_i686 *-musllinux*"
-          # use latest build
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
+          # use latest build; manylinux_2_28 ships gcc>=12 (manylinux2014's
+          # gcc 10.2 is too old for numpy>=2.5 source builds)
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
           CIBW_BEFORE_ALL_MACOS: brew install swig
           CIBW_BEFORE_BUILD: pip install numpy swig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-14 ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-14 ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -101,6 +101,7 @@ jobs:
           CIBW_SKIP: "*-manylinux_i686 *-musllinux*"
           # use latest build
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
           CIBW_BEFORE_ALL_MACOS: brew install swig
           CIBW_BEFORE_BUILD: pip install numpy swig
         run: |
@@ -120,7 +121,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest, macos-latest, macos-14 ]
+        os: [ windows-latest, ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-14 ]
         python-version: ${{ fromJSON(needs.setup.outputs.python-versions) }}
 
     steps:


### PR DESCRIPTION
## Motivation

nlopt currently ships no aarch64 wheels on PyPI, making it uninstallable (or forcing slow/failing source builds) on ARM Linux hosts — NVIDIA DGX Spark, Jetson Thor, GH200, AWS Graviton, etc. This blocks downstream packages that depend on nlopt (e.g. dex-retargeting, used by NVIDIA Isaac Teleop / LeRobot) on ARM.

GitHub now provides free `ubuntu-24.04-arm` runners for public repos, so wheels can be built natively — no QEMU, no cross-compilation.

## Changes

1. **`build_wheels_unix`**: add `ubuntu-24.04-arm` to the matrix + `CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64`.
2. **`test-wheels`**: add `ubuntu-24.04-arm` to the matrix (the existing wheel-discovery logic already handles it: `runner.os=Linux` → `lin`, chunk = matrix os).
3. **Bump x86_64 image to `manylinux_2_28`**: numpy no longer publishes manylinux2014 wheels, so `CIBW_BEFORE_BUILD: pip install numpy` builds numpy from source inside the container and fails manylinux2014's gcc 10.2.1 (`NumPy requires GCC >= 10.3`). This currently breaks the ubuntu-latest job on master too; manylinux_2_28 ships a modern toolchain and matches the aarch64 image family.

## Evidence

Full CI run on my fork — **all build + all 25 test jobs green** (cp310–cp314 × 5 platforms): https://github.com/johnnynunez/nlopt-python/actions/runs/28717151621

Produced artifacts include `nlopt-2.10.0-cp3{10..14}-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl`.

Additionally verified on real ARM hardware (NVIDIA DGX Spark, aarch64, Python 3.12): the cp312 wheel installs with numpy 2.5.1 and solves the NLopt tutorial problem (LD_MMA, two inequality constraints) to the exact optimum (1/3, 8/27).

Note: the `Deploy packages` job failed only on my fork for the expected reason (no PyPI credentials there); it is release-gated and unaffected by this change.