### PR TITLE
Fix sdist to include the C submodule and build files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,7 @@ include LICENSE
 include MANIFEST.in
 include README.md
 include setup.py
-recursive-include extern/nlopt
+include setup.cfg
+include extensions.py
+include CMakeLists.txt
+recursive-include extern/nlopt *


### PR DESCRIPTION
`python setup.py sdist` (and thus the published PyPI sdist) is unbuildable: it ships only setup.py + metadata, with none of the nlopt C sources, extensions.py, or the top-level CMakeLists.txt. `pip install <sdist>` then fails at:

    CMake Error: The source directory "..." does not appear to contain
    CMakeLists.txt

Root cause is MANIFEST.in:
- `recursive-include extern/nlopt` has no file pattern, so setuptools silently includes none of the extern/nlopt submodule.
- extensions.py (imported by setup.py) and the root CMakeLists.txt (passed to CMake by extensions.py) are not listed, so they are excluded as well.

Add the missing `*` pattern and explicitly include extensions.py, CMakeLists.txt, and setup.cfg. The resulting sdist (~2 MB) builds from source with SWIG + NumPy.